### PR TITLE
Added sailfish-content-graphics-default-z1.0 for missing icons

### DIFF
--- a/rpm/jolla-configuration-pinetab.spec
+++ b/rpm/jolla-configuration-pinetab.spec
@@ -28,8 +28,9 @@ Requires: jolla-rnd-device
 
 # Jolla Store Items
 Requires: patterns-sailfish-consumer-generic
-
-Requires: sailfish-content-graphics-z1.25
+# We set the ratio to 1.0 and need the corresponding package for the theme
+Requires: sailfish-content-graphics-default-z1.0
+#Requires: sailfish-content-graphics-z1.25
 Requires: jolla-settings-accounts-extensions-3rd-party-all
 
 # For Mozilla location services (online)

--- a/sparse/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse/var/lib/environment/compositor/droid-hal-device.conf
@@ -9,5 +9,5 @@ QT_QPA_EGLFS_PHYSICAL_HEIGHT=130
 #QT_QPA_EVDEV_DEBUG=1
 QT_QPA_EGLFS_DISABLE_INPUT=1
 #QT_LOGGING_RULES="qt.qpa.input=true"
-LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event2"
+LIPSTICK_OPTIONS="-plugin evdevtouch:/dev/input/event1"
 


### PR DESCRIPTION
We set the ratio to 1.0 in droid-config-pinetab.spec and need the corresponding package for the theme or else all icons will be missing.