### PR TITLE
Mousepointer: use Lipstick native one

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/compositor-configs.txt
+++ b/sparse/etc/dconf/db/vendor.d/compositor-configs.txt
@@ -1,0 +1,2 @@
+[/desktop/sailfish/compositor]
+display_cursor=true

--- a/sparse/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse/var/lib/environment/compositor/droid-hal-device.conf
@@ -10,3 +10,10 @@ QT_QPA_EGLFS_PHYSICAL_HEIGHT=216
 QT_QPA_EGLFS_DISABLE_INPUT=1
 #QT_LOGGING_RULES="qt.qpa.input=true"
 LIPSTICK_OPTIONS="-plugin evdevtouch -plugin evdevkeyboard -plugin evdevmouse"
+
+# disable mouse input completely:
+#LIPSTICK_OPTIONS="-plugin evdevtouch -plugin evdevkeyboard"
+
+# hide mousepointer, we can use the lipstick internal one:
+QT_QPA_EGLFS_HIDECURSOR=1
+QT_QPA_FB_HIDECURSOR=1


### PR DESCRIPTION
Currently the mouse pointer is always displayed (when the Keybord is connected).

Lipstick can display/hide a pointer depending on whether it is moved.

This turns off the "platform" pointer and enables the Lipstick-managed one.


- compositor: disable hardware mouse cursor display
- dconf: make lipstick display native mouse cursor
